### PR TITLE
Lambda を Docker イメージから zip(provided.al2) へ移行 + CI を OIDC 化

### DIFF
--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -27,6 +27,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
 
+      - name: install plugins
+        run: npm install
+
       - name: deploy
         run: sls deploy --stage dev
         env:

--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -2,6 +2,11 @@ name: serverless-dev
 
 on: pull_request
 
+# OIDC でロールを引き受けるために id-token: write が必須。
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: deploy
@@ -23,8 +28,7 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
 
       - name: install plugins

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,12 @@ playground.xcworkspace
 
 .build/
 
+# zip(provided.al2) 版のビルド生成物
+bootstrap
+
+# Node.js (serverless-plugin-scripts などのプラグイン)
+node_modules/
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
-FROM swift:amazonlinux2 as build-image
-
-WORKDIR /work
-COPY ./ ./
-
-RUN swift build -c release --static-swift-stdlib
-RUN chmod +x .build/release/LambdaSwiftServerless
-
-FROM public.ecr.aws/lambda/provided:latest
-
-COPY --from=build-image /work/.build/release/LambdaSwiftServerless /var/runtime/bootstrap
-
-CMD ["dummyHandler"]
+# =====================================================================
+# Docker(ECR イメージ)版の Dockerfile【旧構成・参考用にコメントアウト】
+# ---------------------------------------------------------------------
+# zip(provided.al2)版へ移行したため未使用。
+# zip 版では serverless.yml の scripts フックが swift:amazonlinux2 イメージで
+# `swift build -c release --static-swift-stdlib` を実行し、生成物を bootstrap に
+# コピーするため、この Dockerfile は不要になった。
+# ---------------------------------------------------------------------
+# FROM swift:amazonlinux2 as build-image
+#
+# WORKDIR /work
+# COPY ./ ./
+#
+# RUN swift build -c release --static-swift-stdlib
+# RUN chmod +x .build/release/LambdaSwiftServerless
+#
+# FROM public.ecr.aws/lambda/provided:latest
+#
+# COPY --from=build-image /work/.build/release/LambdaSwiftServerless /var/runtime/bootstrap
+#
+# CMD ["dummyHandler"]
+# =====================================================================

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 自作サーバーレスswift with serverless framework
 
+provided.al2 ランタイム + zip パッケージ構成。
+`sls deploy` 時に serverless-plugin-scripts のフックが Docker
+(swift:amazonlinux2) で静的バイナリ `bootstrap` をビルドして同梱する。
+
+> Docker(ECR イメージ)版から zip 版へ移行済み。旧構成は
+> serverless.yml / Dockerfile にコメントアウトで残してある。
+
 ```bash
+# プラグイン(serverless-plugin-scripts)のインストール
+$ npm install
+
 # deploy
 $ sls deploy --stage <stage_name>
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lambda-swift-sls",
+  "version": "0.1.0",
+  "private": true,
+  "devDependencies": {
+    "serverless-plugin-scripts": "^1.0.2"
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,38 +1,88 @@
 service: lambda-swift-sls
 
+plugins:
+  - serverless-plugin-scripts
+
 custom:
   defaultStage: dev
+  scripts:
+    hooks:
+      # sls deploy / sls package 時に bootstrap を静的ビルドする。
+      # macOS / Apple Silicon でも Lambda(provided.al2, x86_64) 互換の
+      # 静的バイナリを得るため、linux/amd64 を明示して Docker でビルドする。
+      # swift build の生成物 .build/release/LambdaSwiftServerless を
+      # パッケージ直下の bootstrap にコピーする。
+      'before:package:createDeploymentArtifacts': |
+        docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work swift:amazonlinux2 \
+          sh -c "swift build -c release --static-swift-stdlib && cp .build/release/LambdaSwiftServerless bootstrap && chmod +x bootstrap"
 
 provider:
   name: aws
-  runtime: provided
+  runtime: provided.al2
   timeout: 20
   region: ap-northeast-1
-  ecr:
-    images:
-      appImage:
-        path: ./
-        platform: linux/amd64
   stage: ${opt:stage, self:custom.defaultStage}
   # environment:
   #   ${file(./env.yml)}
 
+  # =====================================================================
+  # Docker(ECR イメージ)版の provider 設定【旧構成・参考用にコメントアウト】
+  # ---------------------------------------------------------------------
+  # zip(provided.al2)版へ移行したため未使用。
+  # ---------------------------------------------------------------------
+  # runtime: provided
+  # ecr:
+  #   images:
+  #     appImage:
+  #       path: ./
+  #       platform: linux/amd64
+  # =====================================================================
+
+package:
+  patterns:
+    - '!./**'
+    - bootstrap
+
 functions:
+  # provided ランタイムはパッケージ直下の bootstrap を実行する。
+  # handler 文字列は _HANDLER として渡され、Main.swift の
+  # Serverless.Lambda.Handler(name: "...") と一致させることで処理を振り分ける。
   hello:
-    image:
-      name: appImage
-      command:
-        - hello
+    handler: hello
     events:
       - http:
           path: test
           method: get
   world:
-    image:
-      name: appImage
-      command:
-        - world
+    handler: world
     events:
       - http:
           path: test
           method: post
+
+# =====================================================================
+# Docker(ECR イメージ)版の functions 設定【旧構成・参考用にコメントアウト】
+# ---------------------------------------------------------------------
+# zip(provided.al2)版へ移行したため未使用。
+# zip 版では handler 文字列を _HANDLER として渡して処理を振り分ける。
+# ---------------------------------------------------------------------
+# functions:
+#   hello:
+#     image:
+#       name: appImage
+#       command:
+#         - hello
+#     events:
+#       - http:
+#           path: test
+#           method: get
+#   world:
+#     image:
+#       name: appImage
+#       command:
+#         - world
+#     events:
+#       - http:
+#           path: test
+#           method: post
+# =====================================================================


### PR DESCRIPTION
## 概要
Lambda のデプロイ方式を Docker(ECR イメージ)から zip(provided.al2)へ移行し、GitHub Actions の AWS 認証を OIDC 化しました。

このリポジトリはサンプル実装のため、Docker 版のコードは `serverless.yml` / `Dockerfile` にコメントアウトで残しています。

## 変更点
### zip(provided.al2)版への移行
- `serverless.yml`: `serverless-plugin-scripts` のフックで Docker(`swift:amazonlinux2`)内で静的バイナリ `bootstrap` をビルドし、zip 同梱する構成へ。`runtime: provided.al2`、`handler:` 方式へ変更。旧 Docker/ECR 設定はコメントアウトで残置
- `Dockerfile`: 全内容をコメントアウト（参考用に残置）
- `package.json`: `serverless-plugin-scripts` を追加
- `.gitignore`: `bootstrap` / `node_modules/` を追加
- `README.md`: zip 構成の説明と `npm install` 前提を追記

### CI の OIDC 化
- IAM ロール `lambda-swift-sls-gha-deploy` を引き受ける方式へ変更
- アクセスキー方式を廃止し、`permissions: id-token: write` と `AWS_ROLE_ARN` secret を使用

## 動作確認
ローカルで Docker 版を `sls remove`、zip 版を `sls deploy` 済み。エンドポイントへのテストも成功（GET/POST ともに HTTP 200）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)